### PR TITLE
Add PR template, issue template, and Dependabot config

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Briefly describe the issue or feature request -->
+
+## Rationale
+
+<!-- Explain why this would be useful or what problem it solves:
+- Reason 1
+- Reason 2
+- Reason 3
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why it's needed -->
+
+## Key Changes
+
+<!-- List the main changes that are important for reviewers -->
+
+## Additional Changes
+
+<!-- List any secondary changes, if any -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Scout is a Swift-based code analysis toolkit for mobile repositories. It provides executable tools for counting types, files, imports, and lines of code across git history, with optional Google Sheets integration for metrics tracking.
+
+## Build Commands
+
+```bash
+swift build                           # Build all targets
+swift build --build-tests             # Build including tests
+swift build --product CountTypes      # Build specific executable
+swift run CountTypes [args]           # Run executable directly
+```
+
+## Testing
+
+Uses Swift Testing framework with `@Test` macros. Tests are in `Tests/CodeReaderTests/`.
+
+```bash
+swift test                            # Build and run tests
+swift test --skip-build               # Run tests (after build)
+```
+
+## Linting and Formatting
+
+Uses Swift Format with configuration in `.swift-format.json`.
+
+```bash
+sh scripts/lint.sh                    # Lint with --strict
+sh scripts/format.sh                  # Auto-format in place
+```
+
+## Documentation
+
+Each module has its own README in `Sources/*/README.md` with API details and configuration formats.
+
+## Branching
+
+Each issue must be solved in a separate branch created from fresh main:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <branch-name>
+```
+
+Before creating a PR, run all tests and linter:
+
+```bash
+sh scripts/lint.sh
+swift test
+```
+
+## Documentation Updates
+
+When changing public APIs of any tool, update all relevant READMEs in `Sources/*/README.md`.
+
+## Templates
+
+When creating issues, use the issue template in `.github/ISSUE_TEMPLATE.md`.
+When creating PRs, use the PR template in `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary

Add GitHub templates and Dependabot configuration.

## Key Changes

- Add PR template (`.github/pull_request_template.md`)
- Add issue template (`.github/ISSUE_TEMPLATE.md`)
- Add Dependabot config for Swift and GitHub Actions
- Add AGENTS.md with template usage guidelines

Closes #7
Closes #8
Closes #11