### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why it's needed -->
+
+## Key Changes
+
+<!-- List the main changes that are important for reviewers -->
+
+## Additional Changes
+
+<!-- List any secondary changes, if any -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,9 @@ When changing public APIs of any tool, update all relevant READMEs in `Sources/*
 ## Issues
 
 When creating issues, use the issue template in `.github/ISSUE_TEMPLATE.md`.
+
+## Pull Requests
+
+Each issue must be solved in a separate PR. Never combine multiple issues in one PR unless explicitly told otherwise.
+
+When creating PRs, use the PR template in `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary

Add PR template to standardize pull request descriptions.

## Key Changes

- Add `.github/pull_request_template.md`
- Update AGENTS.md with PR guidelines (one issue per PR, use template)

Closes #7