### PR TITLE
Add release workflow with binary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+env:
+  PRODUCT_NAME: scout
+
+jobs:
+  release:
+    runs-on: macos-26
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Xcode version
+        id: xcode-version
+        run: echo "version=$(<.xcode-version)" >> $GITHUB_OUTPUT
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ steps.xcode-version.outputs.version }}
+
+      - name: Build release binary
+        id: build
+        run: |
+          swift build -c release --product "$PRODUCT_NAME"
+          echo "bin-path=$(swift build -c release --product "$PRODUCT_NAME" --show-bin-path)" >> $GITHUB_OUTPUT
+
+      - name: Package binary
+        id: package
+        run: |
+          ARCHIVE_NAME="${PRODUCT_NAME}_${GITHUB_REF_NAME}_darwin_arm64.tar.gz"
+          tar -czf "${ARCHIVE_NAME}" -C "${{ steps.build.outputs.bin-path }}" "$PRODUCT_NAME"
+          echo "archive-name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: ${{ steps.package.outputs.archive-name }}


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for automated releases with precompiled binaries.

## Key Changes

- Add `.github/workflows/release.yml`
- Triggers on semver tags (e.g. `1.0.0`)
- Builds release binary for macOS arm64
- Creates tar.gz archive and attaches to GitHub Release
- Auto-generates release notes from commits

Closes #6