### PR TITLE
Make --commits argument optional

### DIFF
--- a/Sources/Common/Git.swift
+++ b/Sources/Common/Git.swift
@@ -1,0 +1,16 @@
+import Foundation
+import System
+
+public enum Git {
+    /// Returns the current HEAD commit hash in the specified repository.
+    /// - Parameter repoPath: Path to the repository
+    /// - Returns: The HEAD commit hash
+    public static func headCommit(in repoPath: URL) async throws -> String {
+        let result = try await Shell.execute(
+            "git",
+            arguments: ["rev-parse", "HEAD"],
+            workingDirectory: FilePath(repoPath.path(percentEncoded: false))
+        )
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/CountFiles/Files.swift
+++ b/Sources/CountFiles/Files.swift
@@ -39,8 +39,11 @@ public struct Files: AsyncParsableCommand {
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?
 
-    @Option(name: [.long, .short], help: "Comma-separated list of commit hashes to analyze")
-    public var commits: String
+    @Option(
+        name: [.long, .short],
+        help: "Comma-separated list of commit hashes to analyze. If not provided, uses HEAD."
+    )
+    public var commits: String?
 
     @Flag(name: [.long, .short])
     public var verbose: Bool = false
@@ -62,8 +65,15 @@ public struct Files: AsyncParsableCommand {
         let repoPathURL =
             try URL(string: repoPath) ?! URLError.invalidURL(parameter: "repoPath", value: repoPath)
 
-        let commitHashes = commits.split(separator: ",").map {
-            String($0.trimmingCharacters(in: .whitespaces))
+        let commitHashes: [String]
+        if let commits {
+            commitHashes = commits.split(separator: ",").map {
+                String($0.trimmingCharacters(in: .whitespaces))
+            }
+        } else {
+            let head = try await Git.headCommit(in: repoPathURL)
+            commitHashes = [head]
+            Self.logger.info("No commits specified, using HEAD: \(head)")
         }
 
         var filetypeResults: [(filetype: String, count: Int)] = []

--- a/Sources/CountImports/Imports.swift
+++ b/Sources/CountImports/Imports.swift
@@ -40,8 +40,11 @@ public struct Imports: AsyncParsableCommand {
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?
 
-    @Option(name: [.long, .short], help: "Comma-separated list of commit hashes to analyze")
-    public var commits: String
+    @Option(
+        name: [.long, .short],
+        help: "Comma-separated list of commit hashes to analyze. If not provided, uses HEAD."
+    )
+    public var commits: String?
 
     @Flag(name: [.long, .short])
     public var verbose: Bool = false
@@ -63,8 +66,15 @@ public struct Imports: AsyncParsableCommand {
         let repoPathURL =
             try URL(string: repoPath) ?! URLError.invalidURL(parameter: "repoPath", value: repoPath)
 
-        let commitHashes = commits.split(separator: ",").map {
-            String($0.trimmingCharacters(in: .whitespaces))
+        let commitHashes: [String]
+        if let commits {
+            commitHashes = commits.split(separator: ",").map {
+                String($0.trimmingCharacters(in: .whitespaces))
+            }
+        } else {
+            let head = try await Git.headCommit(in: repoPathURL)
+            commitHashes = [head]
+            Self.logger.info("No commits specified, using HEAD: \(head)")
         }
 
         var importResults: [(importName: String, count: Int)] = []

--- a/Sources/CountLOC/LOC.swift
+++ b/Sources/CountLOC/LOC.swift
@@ -67,8 +67,11 @@ public struct LOC: AsyncParsableCommand {
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?
 
-    @Option(name: [.long, .short], help: "Comma-separated list of commit hashes to analyze")
-    public var commits: String
+    @Option(
+        name: [.long, .short],
+        help: "Comma-separated list of commit hashes to analyze. If not provided, uses HEAD."
+    )
+    public var commits: String?
 
     @Flag(name: [.long, .short])
     public var verbose: Bool = false
@@ -91,8 +94,15 @@ public struct LOC: AsyncParsableCommand {
         let repoPathURL =
             try URL(string: repoPath) ?! URLError.invalidURL(parameter: "repoPath", value: repoPath)
 
-        let commitHashes = commits.split(separator: ",").map {
-            String($0.trimmingCharacters(in: .whitespaces))
+        let commitHashes: [String]
+        if let commits {
+            commitHashes = commits.split(separator: ",").map {
+                String($0.trimmingCharacters(in: .whitespaces))
+            }
+        } else {
+            let head = try await Git.headCommit(in: repoPathURL)
+            commitHashes = [head]
+            Self.logger.info("No commits specified, using HEAD: \(head)")
         }
 
         var locResults: [(metric: String, count: Int)] = []

--- a/Sources/CountTypes/Types.swift
+++ b/Sources/CountTypes/Types.swift
@@ -40,8 +40,11 @@ public struct Types: AsyncParsableCommand {
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?
 
-    @Option(name: [.long, .short], help: "Comma-separated list of commit hashes to analyze")
-    public var commits: String
+    @Option(
+        name: [.long, .short],
+        help: "Comma-separated list of commit hashes to analyze. If not provided, uses HEAD."
+    )
+    public var commits: String?
 
     @Flag(name: [.long, .short])
     public var verbose: Bool = false
@@ -64,8 +67,15 @@ public struct Types: AsyncParsableCommand {
             try URL(string: iosSources)
             ?! URLError.invalidURL(parameter: "iosSources", value: iosSources)
 
-        let commitHashes = commits.split(separator: ",").map {
-            String($0.trimmingCharacters(in: .whitespaces))
+        let commitHashes: [String]
+        if let commits {
+            commitHashes = commits.split(separator: ",").map {
+                String($0.trimmingCharacters(in: .whitespaces))
+            }
+        } else {
+            let head = try await Git.headCommit(in: repoPath)
+            commitHashes = [head]
+            Self.logger.info("No commits specified, using HEAD: \(head)")
         }
 
         var typeResults: [(typeName: String, count: Int)] = []


### PR DESCRIPTION
## Description

Makes the `--commits` argument optional in all CLI tools. When not provided, uses the current HEAD commit of the target repository.

## Changes

- Added `Git.headCommit(in:)` helper in Common module
- Made `--commits` optional in:
  - CountTypes
  - CountFiles
  - CountImports
  - CountLOC
  - ExtractBuildSettings

## Usage

```bash
# Analyze current commit (HEAD) - NEW
swift run CountTypes --ios-sources /path/to/repo

# Analyze specific commits (existing behavior)
swift run CountTypes --ios-sources /path/to/repo --commits "abc123,def456"
```

Closes #30