### PR TITLE
Add --output option to save results to JSON

### DIFF
--- a/Sources/BuildSettingsSDK/BuildSettingsSDK.swift
+++ b/Sources/BuildSettingsSDK/BuildSettingsSDK.swift
@@ -28,7 +28,7 @@ public struct ProjectWithTargets: Sendable {
 }
 
 /// Represents a target with its build settings.
-public struct TargetWithBuildSettings: Sendable {
+public struct TargetWithBuildSettings: Sendable, Codable {
     public let target: String
     public let buildSettings: [String: String]
 
@@ -75,14 +75,8 @@ public struct BuildSettingsSDK: Sendable {
         }
     }
 
-    /// Result of build settings extraction.
-    public struct Result: Sendable {
-        public let targetsWithBuildSettings: [TargetWithBuildSettings]
-
-        public init(targetsWithBuildSettings: [TargetWithBuildSettings]) {
-            self.targetsWithBuildSettings = targetsWithBuildSettings
-        }
-    }
+    /// Result of build settings extraction - array of targets with their build settings.
+    public typealias Result = [TargetWithBuildSettings]
 
     /// Extracts build settings from Xcode projects in the repository.
     public func extractBuildSettings(
@@ -105,7 +99,7 @@ public struct BuildSettingsSDK: Sendable {
             configuration: configuration
         )
 
-        return Result(targetsWithBuildSettings: targetsWithBuildSettings)
+        return targetsWithBuildSettings
     }
 
     /// Checks out a commit and extracts build settings.

--- a/Sources/FilesSDK/FilesSDK.swift
+++ b/Sources/FilesSDK/FilesSDK.swift
@@ -10,15 +10,13 @@ public struct FilesSDK: Sendable {
     public init() {}
 
     /// Result of file counting operation.
-    public struct Result: Sendable {
+    public struct Result: Sendable, Codable {
         public let filetype: String
-        public let files: [URL]
-
-        public var count: Int { files.count }
+        public let files: [String]
 
         public init(filetype: String, files: [URL]) {
             self.filetype = filetype
-            self.files = files
+            self.files = files.map { $0.path }
         }
     }
 

--- a/Sources/LOCSDK/LOCSDK.swift
+++ b/Sources/LOCSDK/LOCSDK.swift
@@ -46,7 +46,7 @@ public struct LOCSDK: Sendable {
     public init() {}
 
     /// Result of LOC counting operation.
-    public struct Result: Sendable {
+    public struct Result: Sendable, Codable {
         public let metric: String
         public let linesOfCode: Int
 

--- a/Sources/TypesSDK/TypesSDK.swift
+++ b/Sources/TypesSDK/TypesSDK.swift
@@ -11,11 +11,9 @@ public struct TypesSDK: Sendable {
     public init() {}
 
     /// Result of type counting operation.
-    public struct Result: Sendable {
+    public struct Result: Sendable, Codable {
         public let typeName: String
         public let types: [String]
-
-        public var count: Int { types.count }
 
         public init(typeName: String, types: [String]) {
             self.typeName = typeName


### PR DESCRIPTION
## Summary

Add ability to save analysis results to a JSON file for all CLI tools.

## Changes

- Add `--output` (`-o`) argument to all tools: `types`, `files`, `imports`, `loc`, `build-settings`
- Make SDK Result types `Codable` for JSON serialization
- **ImportsSDK** now returns files where imports found (not just count)
- **BuildSettingsSDK.Result** is now array of `TargetWithBuildSettings` directly
- Stdout behavior unchanged regardless of `--output`

## Usage

```bash
swift run scout types --ios-sources /path/to/repo --output results.json
swift run scout files --repo-path /path/to/repo -o files.json
swift run scout imports --repo-path /path/to/repo --output imports.json
swift run scout loc --repo-path /path/to/repo --output loc.json
swift run scout build-settings --repo-path /path/to/repo -o settings.json
```

## JSON Output Examples

```json
// types
[{"typeName": "UIViewController", "types": ["HomeVC", "SettingsVC"]}]

// files  
[{"filetype": "swift", "files": [...]}]

// imports
[{"importName": "UIKit", "files": ["Sources/App.swift", ...]}]

// loc
[{"metric": "LOC [...]", "linesOfCode": 12500}]

// build-settings
[{"target": "MyApp", "buildSettings": {"SWIFT_VERSION": "5.0", ...}}]
```

Closes #33