### PR TITLE
feat: require explicit wildcard for generic type matching

### DIFF
--- a/Sources/CodeReader/README.md
+++ b/Sources/CodeReader/README.md
@@ -62,10 +62,11 @@ Checks if a code object inherits from a specific base class. Supports both regul
 **Returns:** `Bool` — `true` if the object inherits from the base class
 
 **Generic Types Support:**
-The method correctly handles generic types. When SourceKitten parses a class inheriting from a generic base class, it returns the full generic type name (e.g., `"JsonAsyncRequest<CancelOrderDTO>"`). The method matches this against the base type name (e.g., `"JsonAsyncRequest"`) by:
-- Checking if the inherited type exactly matches the base type
-- Checking if the inherited type starts with `"BaseType<"` (for generic types)
-- Recursively checking indirect inheritance through parent types
+The method requires explicit wildcard syntax for matching generic types:
+- `"JsonAsyncRequest"` — matches only exact `JsonAsyncRequest` (no generics)
+- `"JsonAsyncRequest<*>"` — matches any generic variant like `JsonAsyncRequest<CancelOrderDTO>`, `JsonAsyncRequest<SomeDTO>`
+
+When SourceKitten parses a class inheriting from a generic base class, it returns the full generic type name (e.g., `"JsonAsyncRequest<CancelOrderDTO>"`). The method also recursively checks indirect inheritance through parent types.
 
 **Examples:**
 ```swift
@@ -76,8 +77,15 @@ let isView = reader.isInherited(
     allObjects: objects
 )
 
-// Generic inheritance - matches "JsonAsyncRequest<SomeDTO>" to "JsonAsyncRequest"
+// Generic inheritance with wildcard - matches "JsonAsyncRequest<SomeDTO>"
 let isJsonRequest = reader.isInherited(
+    objectFromCode: cancelOrderRequest,
+    from: "JsonAsyncRequest<*>",
+    allObjects: objects
+)
+
+// Exact match - does NOT match "JsonAsyncRequest<SomeDTO>"
+let isExactJsonRequest = reader.isInherited(
     objectFromCode: cancelOrderRequest,
     from: "JsonAsyncRequest",
     allObjects: objects

--- a/Sources/Types/README.md
+++ b/Sources/Types/README.md
@@ -60,10 +60,12 @@ Any type name can be used. The tool counts classes/structs that inherit from or 
 { "types": ["XCTestCase", "QuickSpec"] }
 ```
 
-**Generics:**
+**Generics (with wildcard):**
 ```json
-{ "types": ["BaseCoordinator<", "Repository<", "UseCase<"] }
+{ "types": ["BaseCoordinator<*>", "Repository<*>", "UseCase<*>"] }
 ```
+
+Use `<*>` wildcard to match any generic variant (e.g., `BaseCoordinator<*>` matches `BaseCoordinator<SomeFlow>`, `BaseCoordinator<OtherFlow>`). Without the wildcard, only exact type name matches.
 
 **Custom base classes:**
 ```json

--- a/Tests/CodeReaderTests/CodeReaderTests.swift
+++ b/Tests/CodeReaderTests/CodeReaderTests.swift
@@ -24,14 +24,24 @@ struct CodeReaderTests {
         #expect(types == ["HelloView"])
     }
 
-    @Test("Read JsonAsyncRequest generic types")
-    func readJsonAsyncRequest() throws {
+    @Test("Read JsonAsyncRequest generic types with wildcard")
+    func readJsonAsyncRequestWithWildcard() throws {
+        let sut = CodeReader()
+        let objects = try sut.parseFile(from: CodeFiles.genericTypes)
+        let types = objects.filter {
+            sut.isInherited(objectFromCode: $0, from: "JsonAsyncRequest<*>", allObjects: objects)
+        }.map { $0.name }
+        #expect(types == ["CancelOrderRequest", "OrderListRequest", "ProfileRequest"])
+    }
+
+    @Test("Exact type match without wildcard does not match generics")
+    func exactTypeMatchWithoutWildcard() throws {
         let sut = CodeReader()
         let objects = try sut.parseFile(from: CodeFiles.genericTypes)
         let types = objects.filter {
             sut.isInherited(objectFromCode: $0, from: "JsonAsyncRequest", allObjects: objects)
         }.map { $0.name }
-        #expect(types == ["CancelOrderRequest", "OrderListRequest", "ProfileRequest"])
+        #expect(types == [])
     }
 }
 


### PR DESCRIPTION
## Summary

Change generic type matching to require explicit wildcard syntax instead of automatic matching.

- `JsonAsyncRequest` — matches only exact `JsonAsyncRequest` (no generics)
- `JsonAsyncRequest<*>` — matches `JsonAsyncRequest<T>`, `JsonAsyncRequest<SomeDTO>`, etc.

**Rationale:** Explicit is better than implicit — gives users control over whether to include generic variants.

Closes #47

## Key Changes

- Updated `matchesBaseType()` to check for wildcard `<*>` syntax
- Removed implicit generic matching (base type no longer auto-matches generic variants)
- Added tests for both wildcard and exact matching scenarios

## Additional Changes

- Updated CodeReader and Types README documentation with new syntax examples