### PR TITLE
feat: make --repo-path argument optional with current directory default

### DIFF
--- a/Sources/BuildSettings/BuildSettings.swift
+++ b/Sources/BuildSettings/BuildSettings.swift
@@ -34,8 +34,8 @@ public struct BuildSettings: AsyncParsableCommand {
         }
     }
 
-    @Option(name: [.long, .short], help: "Path to repository")
-    public var repoPath: String
+    @Option(name: [.long, .short], help: "Path to repository (default: current directory)")
+    public var repoPath: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?

--- a/Sources/BuildSettings/README.md
+++ b/Sources/BuildSettings/README.md
@@ -5,19 +5,18 @@ Extract build settings from Xcode projects.
 ## Usage
 
 ```bash
-scout build-settings \
-  --repo-path /path/to/repo \
-  --commits "abc123,def456"
+# Run from within a repository (uses current directory)
+scout build-settings --commits "abc123,def456"
+
+# Or specify repository path explicitly
+scout build-settings --repo-path /path/to/repo --commits "abc123,def456"
 ```
 
 ## Arguments
 
-### Required
-
-- `--repo-path, -r <path>` — Path to repository
-
 ### Optional
 
+- `--repo-path, -r <path>` — Path to repository (default: current directory)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Comma-separated list of commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results

--- a/Sources/Files/Files.swift
+++ b/Sources/Files/Files.swift
@@ -34,8 +34,8 @@ public struct Files: AsyncParsableCommand {
         }
     }
 
-    @Option(name: [.long, .short], help: "Path to repository")
-    public var repoPath: String
+    @Option(name: [.long, .short], help: "Path to repository (default: current directory)")
+    public var repoPath: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?

--- a/Sources/Files/README.md
+++ b/Sources/Files/README.md
@@ -5,19 +5,18 @@ Count files by extension across git history.
 ## Usage
 
 ```bash
-scout files \
-  --repo-path /path/to/repo \
-  --commits "abc123,def456"
+# Run from within a repository (uses current directory)
+scout files --commits "abc123,def456"
+
+# Or specify repository path explicitly
+scout files --repo-path /path/to/repo --commits "abc123,def456"
 ```
 
 ## Arguments
 
-### Required
-
-- `--repo-path, -r <path>` — Path to repository
-
 ### Optional
 
+- `--repo-path, -r <path>` — Path to repository (default: current directory)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Comma-separated list of commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results

--- a/Sources/LOC/LOC.swift
+++ b/Sources/LOC/LOC.swift
@@ -33,8 +33,8 @@ public struct LOC: AsyncParsableCommand {
         }
     }
 
-    @Option(name: [.long, .short], help: "Path to repository")
-    public var repoPath: String
+    @Option(name: [.long, .short], help: "Path to repository (default: current directory)")
+    public var repoPath: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?

--- a/Sources/LOC/README.md
+++ b/Sources/LOC/README.md
@@ -5,19 +5,18 @@ Count lines of code using `cloc`.
 ## Usage
 
 ```bash
-scout loc \
-  --repo-path /path/to/repo \
-  --commits "abc123,def456"
+# Run from within a repository (uses current directory)
+scout loc --commits "abc123,def456"
+
+# Or specify repository path explicitly
+scout loc --repo-path /path/to/repo --commits "abc123,def456"
 ```
 
 ## Arguments
 
-### Required
-
-- `--repo-path, -r <path>` — Path to repository
-
 ### Optional
 
+- `--repo-path, -r <path>` — Path to repository (default: current directory)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Comma-separated list of commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results

--- a/Sources/Pattern/Pattern.swift
+++ b/Sources/Pattern/Pattern.swift
@@ -34,8 +34,8 @@ public struct Pattern: AsyncParsableCommand {
         }
     }
 
-    @Option(name: [.long, .short], help: "Path to repository")
-    public var repoPath: String
+    @Option(name: [.long, .short], help: "Path to repository (default: current directory)")
+    public var repoPath: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?

--- a/Sources/Pattern/README.md
+++ b/Sources/Pattern/README.md
@@ -5,19 +5,18 @@ Search for string patterns in source files across git history.
 ## Usage
 
 ```bash
-scout pattern \
-  --repo-path /path/to/repo \
-  --commits "abc123,def456"
+# Run from within a repository (uses current directory)
+scout pattern --commits "abc123,def456"
+
+# Or specify repository path explicitly
+scout pattern --repo-path /path/to/repo --commits "abc123,def456"
 ```
 
 ## Arguments
 
-### Required
-
-- `--repo-path, -r <path>` — Path to repository
-
 ### Optional
 
+- `--repo-path, -r <path>` — Path to repository (default: current directory)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Comma-separated list of commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results

--- a/Sources/Types/README.md
+++ b/Sources/Types/README.md
@@ -5,19 +5,18 @@ Count Swift types by inheritance across git history.
 ## Usage
 
 ```bash
-scout types \
-  --repo-path /path/to/repo \
-  --commits "abc123,def456"
+# Run from within a repository (uses current directory)
+scout types --commits "abc123,def456"
+
+# Or specify repository path explicitly
+scout types --repo-path /path/to/repo --commits "abc123,def456"
 ```
 
 ## Arguments
 
-### Required
-
-- `--repo-path, -r <path>` — Path to repository with Swift sources
-
 ### Optional
 
+- `--repo-path, -r <path>` — Path to repository with Swift sources (default: current directory)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Comma-separated list of commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results

--- a/Sources/Types/Types.swift
+++ b/Sources/Types/Types.swift
@@ -34,8 +34,11 @@ public struct Types: AsyncParsableCommand {
         }
     }
 
-    @Option(name: [.long, .short], help: "Path to repository with Swift sources")
-    public var repoPath: String
+    @Option(
+        name: [.long, .short],
+        help: "Path to repository with Swift sources (default: current directory)"
+    )
+    public var repoPath: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .long, help: "Path to configuration JSON file")
     public var config: String?


### PR DESCRIPTION
## Summary

Make `--repo-path` argument optional for all tools. When not specified, uses current working directory as default.

This simplifies usage when running scout from within a repository and matches behavior of other CLI tools (git, cloc, etc.).

Closes #44

## Key Changes

- Changed `repoPath` from required `String` to optional `String?` in all 5 commands
- Default to `FileManager.default.currentDirectoryPath` when not specified
- Updated help text to indicate `(default: current directory)`

## Additional Changes

- Updated README documentation for all commands (Types, LOC, Files, Pattern, BuildSettings)
- Removed "Required" section from Arguments, moved `--repo-path` to Optional
- Added usage examples showing both with and without `--repo-path`