### PR TITLE
feat: Incremental JSON saving for all metrics

### DIFF
--- a/Sources/BuildSettings/BuildSettings.swift
+++ b/Sources/BuildSettings/BuildSettings.swift
@@ -99,6 +99,7 @@ public struct BuildSettings: AsyncParsableCommand {
         }
 
         var parameterResults: [(parameter: String, targetCount: Int)] = []
+        let jsonWriter = output.map { IncrementalJSONWriter<BuildSettingsSDK.Result>(path: $0) }
 
         Self.logger.info(
             "Will analyze \(commitHashes.count) commits for \(input.buildSettingsParameters.count) parameter(s)",
@@ -158,9 +159,7 @@ public struct BuildSettings: AsyncParsableCommand {
                 }
             }
 
-            if let output {
-                try saveResults(result, to: output)
-            }
+            try jsonWriter?.append(result)
         }
 
         let summary = Summary(parameterResults: parameterResults)
@@ -176,13 +175,5 @@ public struct BuildSettings: AsyncParsableCommand {
         }
 
         GitHubActionsLogHandler.writeSummary(summary)
-    }
-
-    private func saveResults(_ results: BuildSettingsSDK.Result, to path: String) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(results)
-        try data.write(to: URL(fileURLWithPath: path))
-        Self.logger.info("Results saved to \(path)")
     }
 }

--- a/Sources/Common/IncrementalJSONWriter.swift
+++ b/Sources/Common/IncrementalJSONWriter.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Logging
+
+/// Writer that saves results incrementally to JSON file after each append.
+/// This prevents data loss if the process is interrupted (e.g., CI timeout).
+public final class IncrementalJSONWriter<T: Encodable> {
+    private let path: String
+    private var results: [T] = []
+    private let logger = Logger(label: "scout.IncrementalJSONWriter")
+
+    public init(path: String) {
+        self.path = path
+    }
+
+    /// Appends a result and immediately saves to file.
+    public func append(_ result: T) throws {
+        results.append(result)
+        try save()
+        logger.debug(
+            "Results saved incrementally",
+            metadata: ["path": "\(path)", "count": "\(results.count)"]
+        )
+    }
+
+    /// Returns all accumulated results.
+    public var allResults: [T] {
+        results
+    }
+
+    private func save() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(results)
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+}


### PR DESCRIPTION
## Summary

Переделано сохранение в JSON: файл наполняется по мере анализа каждого коммита, а не в конце работы.

**Rationale:**
- На CI степы могут падать по таймауту
- Следующий степ сможет подхватить уже проанализированные данные и выгрузить их
- Не потеряем результаты частичного анализа при сбоях

## Key Changes

- Добавлен `IncrementalJSONWriter<T>` в Common модуль — универсальная утилита для инкрементального сохранения
- Обновлены LOC, Types, Files, Pattern, BuildSettings для сохранения после каждого коммита

## Additional Changes

- Удалены дублирующиеся методы `saveResults()` из всех команд
- BuildSettings теперь тоже использует общий `IncrementalJSONWriter`

Closes #60