### PR TITLE
refactor: unify iteration order - commit first, then analysis

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,7 @@ let package = Package(
                     package: "swift-log-oslog"
                 ),
             ],
-            exclude: ["README.md"],
+            exclude: ["README.md", "GitConfiguration.md"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]

--- a/Sources/Common/Encodable+WriteJSON.swift
+++ b/Sources/Common/Encodable+WriteJSON.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Encodable {
+    /// Writes the value as JSON to the specified file path.
+    public func writeJSON(to path: String) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+}

--- a/Sources/Files/FilesSummary.swift
+++ b/Sources/Files/FilesSummary.swift
@@ -1,0 +1,23 @@
+import Common
+import FilesSDK
+
+struct FilesSummary: JobSummaryFormattable {
+    let results: [FilesSDK.Result]
+
+    var markdown: String {
+        var md = "## CountFiles Summary\n\n"
+
+        if !results.isEmpty {
+            md += "### File Type Counts\n\n"
+            md += "| Commit | File Type | Count |\n"
+            md += "|--------|-----------|-------|\n"
+            for result in results {
+                let commit = result.commit.prefix(7)
+                md += "| `\(commit)` | `.\(result.filetype)` | \(result.files.count) |\n"
+            }
+            md += "\n"
+        }
+
+        return md
+    }
+}

--- a/Sources/FilesSDK/FilesSDK.swift
+++ b/Sources/FilesSDK/FilesSDK.swift
@@ -28,12 +28,20 @@ public struct FilesSDK: Sendable {
 
     /// Result of file counting operation.
     public struct Result: Sendable, Codable {
+        public let commit: String
         public let filetype: String
         public let files: [String]
 
-        public init(filetype: String, files: [URL]) {
+        public init(commit: String = "", filetype: String, files: [URL]) {
+            self.commit = commit
             self.filetype = filetype
             self.files = files.map { $0.path }
+        }
+
+        public init(commit: String, filetype: String, files: [String]) {
+            self.commit = commit
+            self.filetype = filetype
+            self.files = files
         }
     }
 
@@ -106,7 +114,9 @@ public struct FilesSDK: Sendable {
             workingDirectory: FilePath(repoPath.path(percentEncoded: false))
         )
 
-        return try await countFiles(input: input)
+        return try await countFiles(input: input).map {
+            Result(commit: hash, filetype: $0.filetype, files: $0.files)
+        }
     }
 
     private func findFiles(of type: String, in directory: URL) -> [URL] {

--- a/Sources/LOC/LOCSummary.swift
+++ b/Sources/LOC/LOCSummary.swift
@@ -1,0 +1,23 @@
+import Common
+import LOCSDK
+
+struct LOCSummary: JobSummaryFormattable {
+    let results: [LOCSDK.Result]
+
+    var markdown: String {
+        var md = "## CountLOC Summary\n\n"
+
+        if !results.isEmpty {
+            md += "### Lines of Code Counts\n\n"
+            md += "| Commit | Configuration | LOC |\n"
+            md += "|--------|---------------|-----|\n"
+            for result in results {
+                let commit = result.commit.prefix(7)
+                md += "| `\(commit)` | \(result.metric) | \(result.linesOfCode) |\n"
+            }
+            md += "\n"
+        }
+
+        return md
+    }
+}

--- a/Sources/LOCSDK/LOCSDK.swift
+++ b/Sources/LOCSDK/LOCSDK.swift
@@ -73,10 +73,12 @@ public struct LOCSDK: Sendable {
 
     /// Result of LOC counting operation.
     public struct Result: Sendable, Codable {
+        public let commit: String
         public let metric: String
         public let linesOfCode: Int
 
-        public init(metric: String, linesOfCode: Int) {
+        public init(commit: String = "", metric: String, linesOfCode: Int) {
+            self.commit = commit
             self.metric = metric
             self.linesOfCode = linesOfCode
         }
@@ -176,7 +178,9 @@ public struct LOCSDK: Sendable {
             workingDirectory: FilePath(repoPath.path(percentEncoded: false))
         )
 
-        return try await countLOC(input: input)
+        return try await countLOC(input: input).map {
+            Result(commit: hash, metric: $0.metric, linesOfCode: $0.linesOfCode)
+        }
     }
 
     private func foldersToAnalyze(

--- a/Sources/Types/TypesSummary.swift
+++ b/Sources/Types/TypesSummary.swift
@@ -1,0 +1,23 @@
+import Common
+import TypesSDK
+
+struct TypesSummary: JobSummaryFormattable {
+    let results: [TypesSDK.Result]
+
+    var markdown: String {
+        var md = "## CountTypes Summary\n\n"
+
+        if !results.isEmpty {
+            md += "### Type Counts\n\n"
+            md += "| Commit | Type | Count |\n"
+            md += "|--------|------|-------|\n"
+            for result in results {
+                let commit = result.commit.prefix(7)
+                md += "| `\(commit)` | `\(result.typeName)` | \(result.types.count) |\n"
+            }
+            md += "\n"
+        }
+
+        return md
+    }
+}

--- a/Sources/TypesSDK/TypesSDK.swift
+++ b/Sources/TypesSDK/TypesSDK.swift
@@ -28,10 +28,12 @@ public struct TypesSDK: Sendable {
 
     /// Result of type counting operation.
     public struct Result: Sendable, Codable {
+        public let commit: String
         public let typeName: String
         public let types: [String]
 
-        public init(typeName: String, types: [String]) {
+        public init(commit: String = "", typeName: String, types: [String]) {
+            self.commit = commit
             self.typeName = typeName
             self.types = types
         }
@@ -120,7 +122,9 @@ public struct TypesSDK: Sendable {
             workingDirectory: FilePath(repoPath.path(percentEncoded: false))
         )
 
-        return try await countTypes(input: input)
+        return try await countTypes(input: input).map {
+            Result(commit: hash, typeName: $0.typeName, types: $0.types)
+        }
     }
 
     private func findSwiftFiles(in directory: URL) -> [URL] {


### PR DESCRIPTION
## Summary

Unified loop order across all tools: now iterating over commits first, then analyzing types/files/configurations within each commit. This avoids multiple checkouts to the same commits and improves performance when working with git history.

Closes #59

## Key Changes

- **Iteration order**: changed from `items → commits` to `commits → items` in Types, Files, and LOC tools
- **Summary** now includes commit hash for each result, showing full history instead of just the last commit
- Added `commit` field to `TypesSDK.Result`, `FilesSDK.Result`, `LOCSDK.Result` structs
- Extracted Summary structs into separate files: `TypesSummary.swift`, `FilesSummary.swift`, `LOCSummary.swift`
- Added `Encodable.writeJSON(to:)` extension for simplified JSON file writing

## Additional Changes

- Uses existing SDK methods `analyzeCommit(hash:input:)` which analyze all items in a single checkout
- Removed direct usage of `IncrementalJSONWriter` in Types/Files/LOC tools
- Fixed build warning by excluding `GitConfiguration.md` from Common target