### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @AllDmeat


### PR DESCRIPTION
## Summary

Adds CODEOWNERS file to automatically assign @AllDmeat as reviewer for all pull requests.

Closes #54

## Key Changes

- Added `.github/CODEOWNERS` file with @AllDmeat as default owner for all files

## Additional Changes

None