### PR TITLE
Add CLI argument for languages in loc command

### DIFF
--- a/Sources/LOC/LOC.swift
+++ b/Sources/LOC/LOC.swift
@@ -32,6 +32,20 @@ public struct LOC: AsyncParsableCommand {
     @Option(
         name: [.long, .short],
         parsing: .upToNextOption,
+        help: "Paths to include (e.g., Sources App)"
+    )
+    public var include: [String] = []
+
+    @Option(
+        name: [.long, .short],
+        parsing: .upToNextOption,
+        help: "Paths to exclude (e.g., Tests Vendor)"
+    )
+    public var exclude: [String] = []
+
+    @Option(
+        name: [.long, .short],
+        parsing: .upToNextOption,
         help: "Commit hashes to analyze (default: HEAD)"
     )
     public var commits: [String] = []
@@ -65,6 +79,8 @@ public struct LOC: AsyncParsableCommand {
         // Build CLI inputs (git flags are nil when not explicitly set on CLI)
         let cliInputs = LOCCLIInputs(
             languages: languages.nilIfEmpty,
+            include: include.nilIfEmpty,
+            exclude: exclude.nilIfEmpty,
             repoPath: repoPath,
             commits: commits.nilIfEmpty,
             gitClean: gitClean ? true : nil,

--- a/Sources/LOC/LOCCLIInputs.swift
+++ b/Sources/LOC/LOCCLIInputs.swift
@@ -6,6 +6,12 @@ struct LOCCLIInputs: Sendable {
     /// Programming languages to count (e.g., ["Swift", "Objective-C"])
     public let languages: [String]?
 
+    /// Paths to include
+    public let include: [String]?
+
+    /// Paths to exclude
+    public let exclude: [String]?
+
     /// Commit hashes to analyze
     public let commits: [String]?
 
@@ -14,6 +20,8 @@ struct LOCCLIInputs: Sendable {
 
     public init(
         languages: [String]?,
+        include: [String]?,
+        exclude: [String]?,
         repoPath: String?,
         commits: [String]?,
         gitClean: Bool? = nil,
@@ -21,6 +29,8 @@ struct LOCCLIInputs: Sendable {
         initializeSubmodules: Bool? = nil
     ) {
         self.languages = languages
+        self.include = include
+        self.exclude = exclude
         self.commits = commits
         self.git = GitCLIInputs(
             repoPath: repoPath,
@@ -30,8 +40,16 @@ struct LOCCLIInputs: Sendable {
         )
     }
 
-    public init(languages: [String]?, commits: [String]?, git: GitCLIInputs) {
+    public init(
+        languages: [String]?,
+        include: [String]?,
+        exclude: [String]?,
+        commits: [String]?,
+        git: GitCLIInputs
+    ) {
         self.languages = languages
+        self.include = include
+        self.exclude = exclude
         self.commits = commits
         self.git = git
     }

--- a/Sources/LOC/LOCInput+CLI.swift
+++ b/Sources/LOC/LOCInput+CLI.swift
@@ -20,10 +20,16 @@ extension LOCInput {
     ///   - cli: Raw CLI inputs from ArgumentParser
     ///   - config: Configuration loaded from JSON file (optional)
     init(cli: LOCCLIInputs, config: LOCConfig?) {
-        // CLI languages create a single configuration with empty include/exclude
+        // CLI languages create a single configuration; include/exclude default to empty
         let configurations: [LOCConfiguration]
         if let cliLanguages = cli.languages {
-            configurations = [LOCConfiguration(languages: cliLanguages, include: [], exclude: [])]
+            configurations = [
+                LOCConfiguration(
+                    languages: cliLanguages,
+                    include: cli.include ?? [],
+                    exclude: cli.exclude ?? []
+                )
+            ]
         } else {
             configurations = config?.configurations?.map(LOCConfiguration.init) ?? []
         }

--- a/Sources/LOC/README.md
+++ b/Sources/LOC/README.md
@@ -8,6 +8,9 @@ Count lines of code using `cloc`.
 # Specify languages directly
 scout loc Swift Objective-C
 
+# With include/exclude paths
+scout loc Swift --include Sources App --exclude Tests Vendor
+
 # Or use config file
 scout loc --config loc-config.json
 
@@ -23,6 +26,8 @@ scout loc Swift --commits abc123 def456
 
 ### Optional
 
+- `--include, -i <paths>` — Paths to include (e.g., Sources App)
+- `--exclude, -e <paths>` — Paths to exclude (e.g., Tests Vendor)
 - `--config <path>` — Path to configuration JSON file
 - `--commits, -c <hashes>` — Commit hashes to analyze (default: HEAD)
 - `--output, -o <path>` — Path to save JSON results
@@ -34,7 +39,7 @@ scout loc Swift --commits abc123 def456
 
 ## Configuration (Optional)
 
-Configuration file is optional. Use it when you need advanced options like include/exclude paths.
+Configuration file is optional. Use it when you need multiple configurations with different include/exclude paths.
 
 > **Note:** CLI flags take priority over config values.
 
@@ -42,7 +47,10 @@ Configuration file is optional. Use it when you need advanced options like inclu
 # Arguments only (counts all files)
 scout loc Swift Objective-C
 
-# Config only (with include/exclude paths)
+# Arguments with paths
+scout loc Swift --include Sources --exclude Tests
+
+# Config only (multiple configurations)
 scout loc --config loc-config.json
 
 # Arguments override config

--- a/Tests/LOCTests/LOCInputPriorityTests.swift
+++ b/Tests/LOCTests/LOCInputPriorityTests.swift
@@ -11,7 +11,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `CLI repoPath overrides config repoPath`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: "/cli/path", commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: "/cli/path",
+            commits: nil
+        )
         let gitConfig = GitFileConfig(repoPath: "/config/path")
         let config = LOCConfig(configurations: nil, git: gitConfig)
 
@@ -22,7 +28,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `falls back to config repoPath when CLI repoPath is nil`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
         let gitConfig = GitFileConfig(repoPath: "/config/path")
         let config = LOCConfig(configurations: nil, git: gitConfig)
 
@@ -33,7 +45,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `falls back to current directory when both CLI and config repoPath are nil`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
         let config = LOCConfig(configurations: nil, git: nil)
 
         let input = LOCInput(cli: cli, config: config)
@@ -45,7 +63,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `CLI commits override default`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: ["abc123", "def456"])
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: ["abc123", "def456"]
+        )
 
         let input = LOCInput(cli: cli, config: nil)
 
@@ -54,7 +78,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `falls back to HEAD when CLI commits is nil`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
 
         let input = LOCInput(cli: cli, config: nil)
 
@@ -65,7 +95,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `CLI languages override config configurations`() {
-        let cli = LOCCLIInputs(languages: ["Kotlin"], repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: ["Kotlin"],
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
         let locConfig = LOCConfig.LOCConfiguration(
             languages: ["Swift"],
             include: ["Sources"],
@@ -82,8 +118,32 @@ struct LOCInputPriorityTests {
     }
 
     @Test
+    func `CLI languages with include and exclude`() {
+        let cli = LOCCLIInputs(
+            languages: ["Swift"],
+            include: ["Sources", "App"],
+            exclude: ["Tests"],
+            repoPath: nil,
+            commits: nil
+        )
+
+        let input = LOCInput(cli: cli, config: nil)
+
+        #expect(input.configurations.count == 1)
+        #expect(input.configurations[0].languages == ["Swift"])
+        #expect(input.configurations[0].include == ["Sources", "App"])
+        #expect(input.configurations[0].exclude == ["Tests"])
+    }
+
+    @Test
     func `configurations from config are used when CLI languages is nil`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
         let locConfig = LOCConfig.LOCConfiguration(
             languages: ["Swift"],
             include: ["Sources"],
@@ -101,7 +161,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `falls back to empty configurations when both nil`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: nil)
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: nil
+        )
 
         let input = LOCInput(cli: cli, config: nil)
 
@@ -114,6 +180,8 @@ struct LOCInputPriorityTests {
     func `git flags from CLI are applied`() {
         let cli = LOCCLIInputs(
             languages: nil,
+            include: nil,
+            exclude: nil,
             repoPath: nil,
             commits: nil,
             gitClean: true,
@@ -132,7 +200,13 @@ struct LOCInputPriorityTests {
 
     @Test
     func `full priority chain CLI then Config then Default`() {
-        let cli = LOCCLIInputs(languages: nil, repoPath: nil, commits: ["abc123"])
+        let cli = LOCCLIInputs(
+            languages: nil,
+            include: nil,
+            exclude: nil,
+            repoPath: nil,
+            commits: ["abc123"]
+        )
         let gitConfig = GitFileConfig(repoPath: "/from/config")
         let locConfig = LOCConfig.LOCConfiguration(
             languages: ["Swift"],


### PR DESCRIPTION
## Summary

Add the ability to pass `languages` via CLI arguments for the `loc` command, making it consistent with other tools (`types`, `files`, `pattern`).

**Before:** Languages could only be specified via config file with full configuration objects.
**After:** Languages can be passed directly as CLI arguments:
```bash
scout loc Swift Objective-C
```

When using CLI arguments, a single configuration is created with empty `include`/`exclude` paths (counts all files).

## Key Changes

- Add `@Argument` for `languages` in `LOC.swift`
- Add `languages` field to `LOCCLIInputs`
- Update merge logic: CLI languages create a single configuration that overrides config

## Additional Changes

- Add test for CLI > Config priority for `languages`
- Update existing tests to include the new parameter