### PR TITLE
Add typealias support to type search

### DIFF
--- a/Sources/TypesSDK/ObjectFromCode.swift
+++ b/Sources/TypesSDK/ObjectFromCode.swift
@@ -7,4 +7,20 @@ struct ObjectFromCode: Sendable {
     /// Path to the file containing this type
     let filePath: String
     let inheritedTypes: [String]
+    /// Whether this object represents a typealias rather than a concrete type definition.
+    let isTypealias: Bool
+
+    init(
+        name: String,
+        fullName: String,
+        filePath: String,
+        inheritedTypes: [String],
+        isTypealias: Bool = false
+    ) {
+        self.name = name
+        self.fullName = fullName
+        self.filePath = filePath
+        self.inheritedTypes = inheritedTypes
+        self.isTypealias = isTypealias
+    }
 }

--- a/Sources/TypesSDK/TypesSDK.swift
+++ b/Sources/TypesSDK/TypesSDK.swift
@@ -23,11 +23,12 @@ public struct TypesSDK: Sendable {
         }
 
         let types = objects.filter {
-            parser.isInherited(
-                objectFromCode: $0,
-                from: input.typeName,
-                allObjects: objects
-            )
+            !$0.isTypealias
+                && parser.isInherited(
+                    objectFromCode: $0,
+                    from: input.typeName,
+                    allObjects: objects
+                )
         }.sorted(by: { $0.name < $1.name })
 
         Self.logger.debug("Types conforming to \(input.typeName): \(types.map { $0.name })")

--- a/Tests/TypesSDKTests/Samples/Typealias.swift
+++ b/Tests/TypesSDKTests/Samples/Typealias.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// MARK: - Typealias for protocol
+
+protocol Stylable {}
+
+typealias Theme = Stylable
+
+struct DarkTheme: Theme {}
+struct LightTheme: Stylable {}
+
+// MARK: - Typealias for class
+
+class BaseRouter {}
+
+typealias Router = BaseRouter
+
+class MainRouter: Router {}
+class SettingsRouter: BaseRouter {}
+
+// MARK: - Chained typealias
+
+typealias AppTheme = Theme
+
+struct NeonTheme: AppTheme {}

--- a/Tests/TypesSDKTests/TypesSDKTests.swift
+++ b/Tests/TypesSDKTests/TypesSDKTests.swift
@@ -334,6 +334,48 @@ struct TypesSDKTests {
         #expect(identifiableResult.types.names == ["Company", "Person"])
         #expect(nameableResult.types.names == ["Company", "Person"])
     }
+
+    @Test
+    func `When searching for typealias name, should find types conforming to it`() async throws {
+        let samplesURL = try samplesDirectory()
+        let input = TypesSDK.AnalysisInput(repoPath: samplesURL.path, typeName: "Theme")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.names == ["DarkTheme", "NeonTheme"])
+    }
+
+    @Test
+    func `When searching for original type, should find types conforming through typealias`()
+        async throws
+    {
+        let samplesURL = try samplesDirectory()
+        let input = TypesSDK.AnalysisInput(repoPath: samplesURL.path, typeName: "Stylable")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.names == ["DarkTheme", "LightTheme", "NeonTheme"])
+    }
+
+    @Test
+    func `When searching for base class, should find types inheriting through typealias`()
+        async throws
+    {
+        let samplesURL = try samplesDirectory()
+        let input = TypesSDK.AnalysisInput(repoPath: samplesURL.path, typeName: "BaseRouter")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.names == ["MainRouter", "SettingsRouter"])
+    }
+
+    @Test
+    func `When searching for chained typealias, should find types conforming to it`()
+        async throws
+    {
+        let samplesURL = try samplesDirectory()
+        let input = TypesSDK.AnalysisInput(repoPath: samplesURL.path, typeName: "AppTheme")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.names == ["NeonTheme"])
+    }
 }
 
 private func samplesDirectory() throws -> URL {


### PR DESCRIPTION
## Summary

Adds typealias resolution to the type search tool. Previously, searching for `UIView` would not find a class like `class MyView: ViewAlias` where `typealias ViewAlias = UIView`. Now typealias chains are resolved in both directions:
- Searching by alias name (e.g. `Theme`) finds conforming types
- Searching by original type (e.g. `Stylable`) finds types conforming through aliases
- Chained aliases (e.g. `AppTheme → Theme → Stylable`) are fully resolved

## Key Changes

- **`SwiftParser`**: Handle `source.lang.swift.decl.typealias` AST kind — extract target type from source text via byte offsets and create `ObjectFromCode` entries that act as virtual inheritance links
- **`ObjectFromCode`**: Add `isTypealias` flag to distinguish alias entries from real types
- **`TypesSDK.countTypes`**: Filter out typealias entries from final results

## Additional Changes

- New test sample file `Tests/TypesSDKTests/Samples/Typealias.swift` with protocol alias, class alias, and chained alias scenarios
- 4 new tests covering all typealias search directions

## Checklist

- [x] Update `Sources/*/README.md` if public API changed — N/A, no public API changes