### PR TITLE
Demote per-result log messages from notice to info

### DIFF
--- a/Sources/BuildSettingsCLI/BuildSettingsCLI.swift
+++ b/Sources/BuildSettingsCLI/BuildSettingsCLI.swift
@@ -110,7 +110,7 @@ public struct BuildSettingsCLI: AsyncParsableCommand {
 
         let summary = BuildSettingsCLISummary(outputs: outputs)
         if !summary.outputs.isEmpty {
-            Self.logger.notice("\(summary)")
+            Self.logger.info("\(summary)")
         }
         GitHubActionsLogHandler.writeSummary(summary)
     }

--- a/Sources/FilesCLI/FilesCLI.swift
+++ b/Sources/FilesCLI/FilesCLI.swift
@@ -95,7 +95,7 @@ public struct FilesCLI: AsyncParsableCommand {
 
     private func logSummary(_ summary: FilesCLISummary) {
         if !summary.outputs.isEmpty {
-            Self.logger.notice("\(summary)")
+            Self.logger.info("\(summary)")
         }
         GitHubActionsLogHandler.writeSummary(summary)
     }

--- a/Sources/LOCCLI/LOCCLI.swift
+++ b/Sources/LOCCLI/LOCCLI.swift
@@ -117,7 +117,7 @@ public struct LOCCLI: AsyncParsableCommand {
 
     private func logSummary(_ summary: LOCCLISummary) {
         if !summary.outputs.isEmpty {
-            Self.logger.notice("\(summary)")
+            Self.logger.info("\(summary)")
         }
         GitHubActionsLogHandler.writeSummary(summary)
     }

--- a/Sources/PatternCLI/PatternCLI.swift
+++ b/Sources/PatternCLI/PatternCLI.swift
@@ -112,7 +112,7 @@ public struct PatternCLI: AsyncParsableCommand {
 
     private func logSummary(_ summary: PatternCLISummary) {
         if !summary.outputs.isEmpty {
-            Self.logger.notice("\(summary)")
+            Self.logger.info("\(summary)")
         }
         GitHubActionsLogHandler.writeSummary(summary)
     }

--- a/Sources/TypesCLI/TypesCLI.swift
+++ b/Sources/TypesCLI/TypesCLI.swift
@@ -98,7 +98,7 @@ public struct TypesCLI: AsyncParsableCommand {
 
     private func logSummary(_ summary: TypesCLISummary) {
         if !summary.outputs.isEmpty {
-            Self.logger.notice("\(summary)")
+            Self.logger.info("\(summary)")
         }
         GitHubActionsLogHandler.writeSummary(summary)
     }


### PR DESCRIPTION
## Summary

Move per-result log messages from `notice` to `info` level across all CLI tools so that `notice` only contains the summary line.

## Key Changes

- Change per-result messages (`Found X types...`, `Found X files...`, `Found X LOC...`, `Found X matches...`, `Extracted build settings...`) from `.notice` to `.info` in all 5 CLI tools
- Add missing summary notice to LOCCLI for consistency with other tools

## Additional Changes

None

## Checklist

- [x] Update `Sources/*/README.md` if public API changed
- [x] No warnings from our code during build