### PR TITLE
Stop counting protocol conformances as class inheritance

### DIFF
--- a/Sources/Types/ObjectFromCode.swift
+++ b/Sources/Types/ObjectFromCode.swift
@@ -1,3 +1,17 @@
+/// Declaration kind of a parsed Swift type.
+enum TypeKind: Sendable, Equatable {
+    case classType
+    case structType
+    case enumType
+    case protocolType
+    case typealiasType
+
+    /// Value types (struct, enum) cannot inherit from a class.
+    var isValueType: Bool {
+        self == .structType || self == .enumType
+    }
+}
+
 /// Parsed Swift code object with name and inheritance information.
 struct ObjectFromCode: Sendable {
     /// Simple type name (e.g., "AddToCartEvent")
@@ -7,20 +21,27 @@ struct ObjectFromCode: Sendable {
     /// Path to the file containing this type
     let filePath: String
     let inheritedTypes: [String]
+    /// Declaration kind (class, struct, enum, protocol, typealias).
+    let kind: TypeKind
+
     /// Whether this object represents a typealias rather than a concrete type definition.
-    let isTypealias: Bool
+    var isTypealias: Bool { kind == .typealiasType }
+
+    /// Whether this object is nested inside another type (e.g. `Component.View`),
+    /// and therefore only reachable through its qualified name.
+    var isNested: Bool { fullName != name }
 
     init(
         name: String,
         fullName: String,
         filePath: String,
         inheritedTypes: [String],
-        isTypealias: Bool = false
+        kind: TypeKind
     ) {
         self.name = name
         self.fullName = fullName
         self.filePath = filePath
         self.inheritedTypes = inheritedTypes
-        self.isTypealias = isTypealias
+        self.kind = kind
     }
 }

--- a/Sources/Types/SwiftParser.swift
+++ b/Sources/Types/SwiftParser.swift
@@ -56,7 +56,8 @@ struct SwiftParser {
                             name: name,
                             fullName: fullName,
                             filePath: filePath,
-                            inheritedTypes: inheritances
+                            inheritedTypes: inheritances,
+                            kind: typeKind(for: kind ?? "")
                         )
                     )
                 }
@@ -81,7 +82,7 @@ struct SwiftParser {
                             fullName: fullName,
                             filePath: filePath,
                             inheritedTypes: [targetType],
-                            isTypealias: true
+                            kind: .typealiasType
                         )
                     )
                 }
@@ -124,6 +125,17 @@ struct SwiftParser {
             || kind == "source.lang.swift.decl.protocol"
     }
 
+    /// Maps a SourceKitten declaration kind to a `TypeKind`.
+    /// Reference-like declarations (class, actor) map to `.classType`.
+    private func typeKind(for kind: String) -> TypeKind {
+        switch kind {
+        case "source.lang.swift.decl.struct": return .structType
+        case "source.lang.swift.decl.enum": return .enumType
+        case "source.lang.swift.decl.protocol": return .protocolType
+        default: return .classType
+        }
+    }
+
     /// Checks if a code object inherits from the specified base type.
     /// - Parameters:
     ///   - objectFromCode: The object to check
@@ -134,6 +146,23 @@ struct SwiftParser {
         objectFromCode: ObjectFromCode,
         from inheritance: String,
         allObjects: [ObjectFromCode]
+    ) -> Bool {
+        isInherited(
+            objectFromCode: objectFromCode,
+            from: inheritance,
+            allObjects: allObjects,
+            originIsValueType: objectFromCode.kind.isValueType
+        )
+    }
+
+    /// - Parameter originIsValueType: Whether the type that started the lookup is a value type
+    ///   (struct/enum). Value types conform to protocols but cannot subclass a class, so the
+    ///   chain must never pass into a class node when the origin is a value type.
+    private func isInherited(
+        objectFromCode: ObjectFromCode,
+        from inheritance: String,
+        allObjects: [ObjectFromCode],
+        originIsValueType: Bool
     ) -> Bool {
         // Check direct inheritance (including generic types like "JsonAsyncRequest<SomeType>")
         if objectFromCode.inheritedTypes.contains(where: { inheritedType in
@@ -147,14 +176,31 @@ struct SwiftParser {
             // Extract base type name from generic type (e.g., "JsonAsyncRequest<DTO>" -> "JsonAsyncRequest")
             let baseTypeName = extractBaseTypeName(from: className)
 
-            // Check if any parent object matches
-            guard let parentObject = allObjects.first(where: { $0.name == baseTypeName }) else {
+            // Resolve the parent by unqualified name. A nested (member) typealias such as
+            // `Component.View` is only reachable through its qualified name, so it must not
+            // resolve a bare inherited-type reference — otherwise a `struct S: View` conformance
+            // to a protocol would be misrouted into that typealias's target hierarchy.
+            guard
+                let parentObject = allObjects.first(where: { candidate in
+                    candidate.name == baseTypeName
+                        && !(candidate.isTypealias && candidate.isNested)
+                })
+            else {
                 return false
             }
+
+            // A value type (struct/enum) cannot subclass a class. If the origin is a value type
+            // and the chain reaches a class node, this is a protocol conformance being misread
+            // as class inheritance — reject it.
+            if originIsValueType && parentObject.kind == .classType {
+                return false
+            }
+
             return isInherited(
                 objectFromCode: parentObject,
                 from: inheritance,
-                allObjects: allObjects
+                allObjects: allObjects,
+                originIsValueType: originIsValueType
             )
         }
     }

--- a/Tests/TypesTests/Samples/ViewInheritanceCollision.swift
+++ b/Tests/TypesTests/Samples/ViewInheritanceCollision.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+// Reproduces the SwiftUI-into-UIKit misbucketing observed in dodo-mobile-ios.
+//
+// Reuses `DodoView` (a UIView subclass declared in Views/UIViews.swift) so the
+// legitimate `UIView` metric is unchanged; only the phantom conformers below
+// must be excluded.
+
+// MARK: - Defect: nested `View` typealias shadows the SwiftUI `View` protocol
+
+// Real DUIKit component pattern: a component exposes its UIKit view through a
+// *nested* `View` typealias (fullName `BadgeComponent.View`).
+enum BadgeComponent {
+    typealias View = DodoView
+}
+
+// A reference type that conforms to the SwiftUI `View` protocol. It must NOT be
+// counted as a UIView subclass just because a nested `BadgeComponent.View`
+// typealias happens to alias a UIView subclass — a nested member typealias is
+// only reachable as `BadgeComponent.View`, never as bare `View`.
+final class ReferenceSwiftUIView: View {
+    var body: some View { Text("reference") }
+}
+
+// MARK: - Defect: a value type cannot inherit from a class
+
+// A top-level alias whose target is a UIKit view. Survives nested-typealias
+// scoping, so only the value-type rule can exclude the conformer below.
+typealias Panel = DodoView
+
+// A value type whose inheritance list resolves to a class must NOT be counted as
+// inheriting that class — structs and enums cannot subclass a class.
+struct ValueTypePanel: Panel {}

--- a/Tests/TypesTests/TypesTests.swift
+++ b/Tests/TypesTests/TypesTests.swift
@@ -26,7 +26,32 @@ struct TypesTests {
 
         #expect(result.typeName == "View")
         // HelloView uses `View`, QualifiedView uses `SwiftUI.View` - both should be found
-        #expect(result.types.names == ["HelloView", "QualifiedView"])
+        #expect(result.types.names == ["HelloView", "QualifiedView", "ReferenceSwiftUIView"])
+    }
+
+    @Test
+    func `Protocol conformance is not misrouted to a class by a nested typealias`() async throws {
+        let samplesURL = try samplesDirectory()
+
+        let input = Types.AnalysisInput(repoPath: samplesURL.path, typeName: "UIView")
+        let result = try await sut.countTypes(input: input)
+
+        // `ReferenceSwiftUIView: View` conforms to the SwiftUI `View` protocol. A nested
+        // `BadgeComponent.View` typealias aliases a UIView subclass, but it is not reachable
+        // as bare `View`, so the conformer must not be counted as a UIView.
+        #expect(!result.types.names.contains("ReferenceSwiftUIView"))
+    }
+
+    @Test
+    func `Value type does not inherit a class reached via a typealias`() async throws {
+        let samplesURL = try samplesDirectory()
+
+        let input = Types.AnalysisInput(repoPath: samplesURL.path, typeName: "UIView")
+        let result = try await sut.countTypes(input: input)
+
+        // `ValueTypePanel` is a struct; `Panel` aliases a UIView subclass. A value type
+        // cannot subclass a class, so it must not be counted as a UIView.
+        #expect(!result.types.names.contains("ValueTypePanel"))
     }
 
     @Test
@@ -144,7 +169,7 @@ struct TypesTests {
         #expect(uiViewResult.typeName == "UIView")
         #expect(uiViewResult.types.names == ["AwesomeView", "DodoView"])
         #expect(viewResult.typeName == "View")
-        #expect(viewResult.types.names == ["HelloView", "QualifiedView"])
+        #expect(viewResult.types.names == ["HelloView", "QualifiedView", "ReferenceSwiftUIView"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

`scout types` could count a SwiftUI `struct S: View` as a `UIView` subclass. The inheritance resolver conflated protocol conformance with class inheritance and let a nested member typealias shadow a protocol, so any value type conforming to a protocol whose name collided with a class-aliasing typealias got dumped into the class bucket.

The effect is layout-dependent because the offending typealias is resolved by unqualified first-match over the file enumeration order. On dodo-mobile-ios the `UIView` metric read **646** on the flat repo layout and **286** on the modular one, with ~355 phantom SwiftUI views making up the difference — a measurement artifact, not real code.

## Key Changes

- `ObjectFromCode` gains a `kind` (class / struct / enum / protocol / typealias) so the resolver can reason about what a type actually is.
- `isInherited` now skips **nested** member typealiases (e.g. `Component.View`) during parent resolution — they are only reachable through their qualified name, so they must not resolve a bare inherited-type reference.
- `isInherited` now rejects an inheritance edge from a **value type** origin (struct / enum) into a **class** node — a value type conforms to protocols but cannot subclass a class.

Result: the `UIView` metric is layout-independent. The flat 07-03 tree drops from 646 to 286, matching the modular layout; the current layout is unchanged (`UIViewController` 184, `UIView` 286, `View` 367).

## Additional Changes

- New sample fixture `Tests/TypesTests/Samples/ViewInheritanceCollision.swift` reproducing both defects.
- Two new tests in `TypesTests` covering nested-typealias shadowing and value-type-through-class.

## Checklist

- [x] Update `Sources/*/README.md` if public API changed — no public API change (internal parser only)
- [x] No warnings from our code during build
- [x] `sh scripts/lint.sh` clean
- [x] `swift test` — 230 tests pass
- [x] `periphery scan --skip-build --strict` — no unused code