### PR TITLE
Resolve external base classes via Xcode SDK

### DIFF
--- a/Sources/Types/ExternalHierarchyProvider.swift
+++ b/Sources/Types/ExternalHierarchyProvider.swift
@@ -1,0 +1,10 @@
+/// Provides class-inheritance hierarchy for types that live outside the analyzed source
+/// (e.g. UIKit's `UICollectionViewCell : UIView`), so inheritance chains can be resolved
+/// past the source boundary.
+protocol ExternalHierarchyProvider: Sendable {
+    /// Returns external `subclass -> [superclass]` class-inheritance edges for the given
+    /// imported modules, expressed as `ObjectFromCode` entries (kind `.classType`) that can
+    /// be merged into the parsed-source pool.
+    /// - Parameter modules: Module names imported by the analyzed source (e.g. `["UIKit"]`).
+    func externalObjects(forModules modules: Set<String>) async throws -> [ObjectFromCode]
+}

--- a/Sources/Types/ImportScanner.swift
+++ b/Sources/Types/ImportScanner.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Extracts imported module names from Swift source files.
+///
+/// Used to decide which external modules' inheritance hierarchy needs resolving,
+/// derived from the source itself rather than a hardcoded list.
+enum ImportScanner {
+    /// Collects the set of module names imported across the given Swift files.
+    static func modules(in files: [URL]) -> Set<String> {
+        var modules: Set<String> = []
+        for file in files {
+            guard let contents = try? String(contentsOf: file, encoding: .utf8) else { continue }
+            for line in contents.split(whereSeparator: \.isNewline) {
+                if let module = module(fromLine: line) {
+                    modules.insert(module)
+                }
+            }
+        }
+        return modules
+    }
+
+    /// Returns the imported module name for a single line, or `nil` if it is not an import.
+    ///
+    /// Handles leading attributes (`@_exported import X`), declaration imports
+    /// (`import class UIKit.UIView` → `UIKit`), and submodule paths (first component wins).
+    static func module(fromLine line: Substring) -> String? {
+        var tokens = line.split(whereSeparator: \.isWhitespace).map(String.init)
+
+        while let first = tokens.first, first.hasPrefix("@") {
+            tokens.removeFirst()
+        }
+
+        guard tokens.first == "import" else { return nil }
+        tokens.removeFirst()
+
+        let declarationKinds: Set<String> = [
+            "class", "struct", "enum", "protocol", "typealias", "func", "var", "let",
+        ]
+        if let first = tokens.first, declarationKinds.contains(first) {
+            tokens.removeFirst()
+        }
+
+        guard let path = tokens.first else { return nil }
+        let identifier = path.prefix { $0.isLetter || $0.isNumber || $0 == "_" }
+        return identifier.isEmpty ? nil : String(identifier)
+    }
+}

--- a/Sources/Types/SymbolGraphHierarchyProvider.swift
+++ b/Sources/Types/SymbolGraphHierarchyProvider.swift
@@ -1,0 +1,106 @@
+import Common
+import Foundation
+import Logging
+
+/// Resolves external class inheritance by extracting the real hierarchy from the Xcode SDK
+/// via `swift-symbolgraph-extract`. No UIKit knowledge is hardcoded — module names come from
+/// the source's own imports, and the hierarchy comes from Apple's SDK.
+///
+/// If the SDK or the extractor is unavailable, or a module cannot be extracted, resolution
+/// degrades gracefully to source-only analysis (returns no external objects).
+actor SymbolGraphHierarchyProvider: ExternalHierarchyProvider {
+    private static let logger = Logger(label: "scout.SymbolGraphHierarchyProvider")
+
+    /// Extracted objects cached per `module|sdk|target`; the SDK hierarchy is stable across
+    /// git commits, so each module is extracted at most once per run.
+    private var cache: [String: [ObjectFromCode]] = [:]
+
+    func externalObjects(forModules modules: Set<String>) async throws -> [ObjectFromCode] {
+        guard let sdkPath = await Self.sdkPath(), let target = Self.target(forSDKPath: sdkPath)
+        else {
+            Self.logger.info("Xcode SDK unavailable; resolving inheritance from source only")
+            return []
+        }
+
+        var result: [ObjectFromCode] = []
+        for module in modules.sorted() {
+            let key = "\(module)|\(sdkPath)|\(target)"
+            if let cached = cache[key] {
+                result += cached
+                continue
+            }
+            let objects = await extract(module: module, sdkPath: sdkPath, target: target)
+            cache[key] = objects
+            result += objects
+        }
+        return result
+    }
+
+    private func extract(module: String, sdkPath: String, target: String) async -> [ObjectFromCode]
+    {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scout-symbolgraph-\(module)-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: outputDirectory,
+                withIntermediateDirectories: true
+            )
+            try await Shell.execute(
+                "xcrun",
+                arguments: [
+                    "swift-symbolgraph-extract",
+                    "-module-name", module,
+                    "-sdk", sdkPath,
+                    "-target", target,
+                    "-output-dir", outputDirectory.path(percentEncoded: false),
+                ]
+            )
+
+            let files = try FileManager.default.contentsOfDirectory(
+                at: outputDirectory,
+                includingPropertiesForKeys: nil
+            )
+            .filter { $0.pathExtension == "json" }
+
+            return try files.flatMap { file in
+                try SymbolGraphParser.objects(fromSymbolGraphJSON: Data(contentsOf: file))
+            }
+        } catch {
+            Self.logger.info(
+                "Skipping module '\(module)': \(error.localizedDescription)"
+            )
+            return []
+        }
+    }
+
+    private static func sdkPath() async -> String? {
+        let path = try? await Shell.execute(
+            "xcrun",
+            arguments: ["--sdk", "iphonesimulator", "--show-sdk-path"]
+        )
+        guard let path, !path.isEmpty else { return nil }
+        return path
+    }
+
+    /// Derives a target triple from an SDK path such as `.../iPhoneSimulator26.5.sdk`.
+    static func target(forSDKPath sdkPath: String) -> String? {
+        guard let name = sdkPath.split(separator: "/").last,
+            name.hasPrefix("iPhoneSimulator"),
+            name.hasSuffix(".sdk")
+        else { return nil }
+
+        let version = name.dropFirst("iPhoneSimulator".count).dropLast(".sdk".count)
+        guard !version.isEmpty else { return nil }
+        return "\(currentArchitecture)-apple-ios\(version)-simulator"
+    }
+
+    private static var currentArchitecture: String {
+        #if arch(arm64)
+            return "arm64"
+        #else
+            return "x86_64"
+        #endif
+    }
+}

--- a/Sources/Types/SymbolGraphParser.swift
+++ b/Sources/Types/SymbolGraphParser.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Parses a Swift symbol graph (produced by `swift-symbolgraph-extract`) into class
+/// inheritance edges expressed as `ObjectFromCode`.
+///
+/// Only `inheritsFrom` relationships are used, so protocol conformances (`conformsTo`)
+/// never masquerade as class inheritance.
+enum SymbolGraphParser {
+    private struct SymbolGraph: Decodable {
+        struct Symbol: Decodable {
+            struct Identifier: Decodable { let precise: String }
+            struct Names: Decodable { let title: String }
+            let identifier: Identifier
+            let names: Names
+        }
+
+        struct Relationship: Decodable {
+            let kind: String
+            let source: String
+            let target: String
+        }
+
+        let symbols: [Symbol]
+        let relationships: [Relationship]
+    }
+
+    /// Decodes symbol graph JSON and returns one `ObjectFromCode` per `inheritsFrom` edge.
+    static func objects(fromSymbolGraphJSON data: Data) throws -> [ObjectFromCode] {
+        let graph = try JSONDecoder().decode(SymbolGraph.self, from: data)
+
+        let titleByUSR = Dictionary(
+            graph.symbols.map { ($0.identifier.precise, $0.names.title) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return graph.relationships
+            .filter { $0.kind == "inheritsFrom" }
+            .compactMap { relationship in
+                guard let subclass = titleByUSR[relationship.source] else { return nil }
+                let superclass =
+                    titleByUSR[relationship.target] ?? name(fromUSR: relationship.target)
+                return ObjectFromCode(
+                    name: subclass,
+                    fullName: subclass,
+                    filePath: "<symbolgraph>",
+                    inheritedTypes: [superclass],
+                    kind: .classType
+                )
+            }
+    }
+
+    /// Derives a readable type name from a USR when no symbol declares it.
+    /// For example, `c:objc(cs)NSObject` → `NSObject`.
+    private static func name(fromUSR usr: String) -> String {
+        if let range = usr.range(of: "(cs)") {
+            return String(usr[range.upperBound...])
+        }
+        return usr
+    }
+}

--- a/Sources/Types/Types.swift
+++ b/Sources/Types/Types.swift
@@ -7,7 +7,15 @@ import System
 public struct Types: Sendable {
     private static let logger = Logger(label: "scout.Types")
 
-    public init() {}
+    private let hierarchyProvider: any ExternalHierarchyProvider
+
+    public init() {
+        self.init(hierarchyProvider: SymbolGraphHierarchyProvider())
+    }
+
+    init(hierarchyProvider: any ExternalHierarchyProvider) {
+        self.hierarchyProvider = hierarchyProvider
+    }
 
     /// Counts types inherited from the specified base type in current repository state.
     /// - Parameter input: Analysis input with repository path and type name
@@ -22,12 +30,19 @@ public struct Types: Sendable {
             try parser.parseFile(from: $0)
         }
 
+        // Resolve inheritance past the source boundary (e.g. UICollectionViewCell -> UIView)
+        // by merging in external class-inheritance edges for the modules the source imports.
+        // Source objects come first so name lookups prefer local definitions.
+        let modules = ImportScanner.modules(in: swiftFiles)
+        let externalObjects = try await hierarchyProvider.externalObjects(forModules: modules)
+        let allObjects = objects + externalObjects
+
         let types = objects.filter {
             !$0.isTypealias
                 && parser.isInherited(
                     objectFromCode: $0,
                     from: input.typeName,
-                    allObjects: objects
+                    allObjects: allObjects
                 )
         }.sorted(by: { $0.name < $1.name })
 

--- a/Sources/TypesCLI/README.md
+++ b/Sources/TypesCLI/README.md
@@ -15,6 +15,22 @@ scout types --config types-config.json
 scout types UIView --commits abc123 def456
 ```
 
+## Inheritance Resolution
+
+Inheritance chains are followed through the analyzed source. Types whose base class lives
+outside the source — e.g. `class ProductCell: UICollectionViewCell` — are still resolved by
+extracting the real class hierarchy from the Xcode SDK via `swift-symbolgraph-extract`, for the
+modules the source imports. So a `UICollectionViewCell`, `UITableViewCell`, or `UIControl`
+subclass is counted under `UIView`, with no hardcoded UIKit mapping.
+
+Only class inheritance (`inheritsFrom`) is used from the SDK, so protocol conformances are not
+mistaken for subclassing.
+
+If Xcode or the SDK is unavailable, resolution degrades gracefully to source-only analysis.
+
+> **Note:** Each imported module is extracted once and cached across commits. The first
+> analysis of a large module such as UIKit adds a few seconds.
+
 ## Arguments
 
 ### Positional

--- a/Tests/TypesTests/ExternalHierarchyTests.swift
+++ b/Tests/TypesTests/ExternalHierarchyTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import Types
+
+struct ExternalHierarchyTests {
+    @Test
+    func `Subclasses of UIKit view types resolve to UIView via external hierarchy`() async throws {
+        let cellsURL = try cellsSamplesDirectory()
+        let provider = StubHierarchyProvider(edges: [
+            "UICollectionViewCell": "UICollectionReusableView",
+            "UICollectionReusableView": "UIView",
+            "UITableViewCell": "UIView",
+            "UIControl": "UIView",
+            "UIButton": "UIControl",
+            "UIView": "UIResponder",
+        ])
+        let sut = Types(hierarchyProvider: provider)
+
+        let input = Types.AnalysisInput(repoPath: cellsURL.path, typeName: "UIView")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(
+            result.types.names == [
+                "LikeButton", "OrderTableCell", "PriceControl", "ProductCollectionCell",
+            ]
+        )
+    }
+
+    @Test
+    func `Without external hierarchy, UIKit subclasses are not resolved to UIView`() async throws {
+        let cellsURL = try cellsSamplesDirectory()
+        let sut = Types(hierarchyProvider: StubHierarchyProvider())
+
+        let input = Types.AnalysisInput(repoPath: cellsURL.path, typeName: "UIView")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.isEmpty)
+    }
+
+    @Test
+    func `Direct base class is still found when external hierarchy is present`() async throws {
+        let cellsURL = try cellsSamplesDirectory()
+        let provider = StubHierarchyProvider(edges: [
+            "UIControl": "UIView",
+            "UIButton": "UIControl",
+        ])
+        let sut = Types(hierarchyProvider: provider)
+
+        let input = Types.AnalysisInput(repoPath: cellsURL.path, typeName: "UIControl")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(result.types.names == ["LikeButton", "PriceControl"])
+    }
+}

--- a/Tests/TypesTests/Samples/Cells/CellsAndControls.swift
+++ b/Tests/TypesTests/Samples/Cells/CellsAndControls.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+final class ProductCollectionCell: UICollectionViewCell {}
+
+final class OrderTableCell: UITableViewCell {}
+
+final class PriceControl: UIControl {}
+
+final class LikeButton: UIButton {}

--- a/Tests/TypesTests/StubHierarchyProvider.swift
+++ b/Tests/TypesTests/StubHierarchyProvider.swift
@@ -1,0 +1,20 @@
+@testable import Types
+
+/// Test double for `ExternalHierarchyProvider` that returns a fixed set of
+/// `subclass -> superclass` class-inheritance edges without touching the SDK.
+struct StubHierarchyProvider: ExternalHierarchyProvider {
+    /// Maps a subclass name to its direct superclass name.
+    var edges: [String: String] = [:]
+
+    func externalObjects(forModules modules: Set<String>) async throws -> [ObjectFromCode] {
+        edges.map { subclass, superclass in
+            ObjectFromCode(
+                name: subclass,
+                fullName: subclass,
+                filePath: "<stub>",
+                inheritedTypes: [superclass],
+                kind: .classType
+            )
+        }
+    }
+}

--- a/Tests/TypesTests/SymbolGraphHierarchyProviderIntegrationTests.swift
+++ b/Tests/TypesTests/SymbolGraphHierarchyProviderIntegrationTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import Types
+
+/// End-to-end coverage of the real Xcode-SDK-backed provider.
+///
+/// Gated behind the `SCOUT_SDK_TESTS` environment variable because it shells out to
+/// `swift-symbolgraph-extract` (requires Xcode, ~seconds per module). Run with:
+/// `SCOUT_SDK_TESTS=1 swift test --filter SymbolGraphHierarchyProviderIntegrationTests`.
+struct SymbolGraphHierarchyProviderIntegrationTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["SCOUT_SDK_TESTS"] != nil))
+    func `Real Xcode SDK resolves UIKit subclasses to UIView end-to-end`() async throws {
+        let cellsURL = try cellsSamplesDirectory()
+        let sut = Types(hierarchyProvider: SymbolGraphHierarchyProvider())
+
+        let input = Types.AnalysisInput(repoPath: cellsURL.path, typeName: "UIView")
+        let result = try await sut.countTypes(input: input)
+
+        #expect(
+            result.types.names == [
+                "LikeButton", "OrderTableCell", "PriceControl", "ProductCollectionCell",
+            ]
+        )
+    }
+}

--- a/Tests/TypesTests/SymbolGraphParserTests.swift
+++ b/Tests/TypesTests/SymbolGraphParserTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import Types
+
+struct SymbolGraphParserTests {
+    @Test
+    func `Parses inheritsFrom relationships into class inheritance edges`() throws {
+        let json = """
+            {
+              "symbols": [
+                { "identifier": { "precise": "s:5UIKit20UICollectionViewCellC" },
+                  "names": { "title": "UICollectionViewCell" },
+                  "kind": { "identifier": "swift.class" } },
+                { "identifier": { "precise": "s:5UIKit24UICollectionReusableViewC" },
+                  "names": { "title": "UICollectionReusableView" },
+                  "kind": { "identifier": "swift.class" } },
+                { "identifier": { "precise": "s:5UIKit6UIViewC" },
+                  "names": { "title": "UIView" },
+                  "kind": { "identifier": "swift.class" } }
+              ],
+              "relationships": [
+                { "kind": "inheritsFrom",
+                  "source": "s:5UIKit20UICollectionViewCellC",
+                  "target": "s:5UIKit24UICollectionReusableViewC" },
+                { "kind": "inheritsFrom",
+                  "source": "s:5UIKit24UICollectionReusableViewC",
+                  "target": "s:5UIKit6UIViewC" }
+              ]
+            }
+            """
+
+        let objects = try SymbolGraphParser.objects(fromSymbolGraphJSON: Data(json.utf8))
+        let inheritance = Dictionary(
+            uniqueKeysWithValues: objects.map { ($0.name, $0.inheritedTypes) }
+        )
+
+        #expect(inheritance["UICollectionViewCell"] == ["UICollectionReusableView"])
+        #expect(inheritance["UICollectionReusableView"] == ["UIView"])
+        #expect(objects.allSatisfy { $0.kind == .classType })
+    }
+
+    @Test
+    func `Falls back to Objective-C USR name when target symbol is absent`() throws {
+        let json = """
+            {
+              "symbols": [
+                { "identifier": { "precise": "s:5UIKit11UIResponderC" },
+                  "names": { "title": "UIResponder" },
+                  "kind": { "identifier": "swift.class" } }
+              ],
+              "relationships": [
+                { "kind": "inheritsFrom",
+                  "source": "s:5UIKit11UIResponderC",
+                  "target": "c:objc(cs)NSObject" }
+              ]
+            }
+            """
+
+        let objects = try SymbolGraphParser.objects(fromSymbolGraphJSON: Data(json.utf8))
+        let responder = try #require(objects.first { $0.name == "UIResponder" })
+
+        #expect(responder.inheritedTypes == ["NSObject"])
+    }
+
+    @Test
+    func `Ignores non-inheritance relationships such as conformsTo`() throws {
+        let json = """
+            {
+              "symbols": [
+                { "identifier": { "precise": "s:5UIKit6UIViewC" },
+                  "names": { "title": "UIView" },
+                  "kind": { "identifier": "swift.class" } }
+              ],
+              "relationships": [
+                { "kind": "conformsTo",
+                  "source": "s:5UIKit6UIViewC",
+                  "target": "s:s8SendableP" }
+              ]
+            }
+            """
+
+        let objects = try SymbolGraphParser.objects(fromSymbolGraphJSON: Data(json.utf8))
+
+        #expect(objects.isEmpty)
+    }
+}

--- a/Tests/TypesTests/TestSupport.swift
+++ b/Tests/TypesTests/TestSupport.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Directory holding the isolated `UICollectionViewCell` / `UITableViewCell` / `UIControl`
+/// subclass samples used by external-hierarchy tests.
+func cellsSamplesDirectory() throws -> URL {
+    guard let url = Bundle.module.resourceURL?.appendingPathComponent("Samples/Cells") else {
+        throw CocoaError(.fileNoSuchFile)
+    }
+    return url
+}

--- a/Tests/TypesTests/TypesTests.swift
+++ b/Tests/TypesTests/TypesTests.swift
@@ -5,7 +5,8 @@ import Testing
 @testable import Types
 
 struct TypesTests {
-    let sut = Types()
+    // Source-only resolution: no external hierarchy, keeping these unit tests hermetic and fast.
+    let sut = Types(hierarchyProvider: StubHierarchyProvider())
 
     @Test
     func `When searching for UIView types, should find all UIView subclasses`() async throws {


### PR DESCRIPTION
## Summary

Subclasses of UIKit base classes were not counted under `UIView`. `scout types UIView` returned 0 for a codebase full of `UICollectionViewCell` / `UITableViewCell` / `UIControl` subclasses, because the tool only followed inheritance chains that were fully visible in the analyzed source, and the `UICollectionViewCell → UIView` link lives in UIKit, not the project.

This resolves inheritance past the source boundary using the real class hierarchy from the Xcode SDK — with no hardcoded UIKit mapping.

## Key Changes

- `SymbolGraphHierarchyProvider` extracts the real class hierarchy from the Xcode SDK via `swift-symbolgraph-extract`, for the modules the source actually imports. Module names come from the source's own `import` statements (`ImportScanner`), so nothing about UIKit is baked into the tool.
- Only `inheritsFrom` edges are used, so protocol conformances are never mistaken for subclassing.
- External edges are merged into the existing inheritance-resolution pool as `ObjectFromCode`, so the multi-hop resolver counts a `UICollectionViewCell` / `UIControl` subclass under `UIView` unchanged.
- Extraction is cached per module across commits and degrades gracefully to source-only analysis when Xcode / the SDK is unavailable.
- `ExternalHierarchyProvider` is injected into `Types`, keeping the existing unit tests hermetic (they inject an empty provider) and letting the SDK path be exercised by a gated integration test.

## Additional Changes

- New unit tests: external-hierarchy resolution (via a stub provider) and symbol-graph JSON parsing (via fixtures) — fully hermetic.
- New integration test exercising the real Xcode SDK end-to-end, gated behind `SCOUT_SDK_TESTS` so normal CI stays fast.
- `Sources/TypesCLI/README.md` documents the SDK-backed resolution and its graceful degradation.

## Checklist

- [x] Update `Sources/*/README.md` if public API changed
- [x] No warnings from our code during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
