### PR TITLE
Treat all warnings as errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "82b1dc4f60601f07f7bff838e25ce7a8f64f9f77daf04571012bfa06b1e05452",
+  "originHash" : "82b590a1b8f1b5e178f09f2cd6358fe0ad0dd5b3a79d66df09d1e4264ed46444",
   "pins" : [
     {
       "identity" : "sourcekitten",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-subprocess",
       "state" : {
-        "revision" : "ba5888ad7758cbcbe7abebac37860b1652af2d9c",
-        "version" : "0.3.0"
+        "revision" : "11633673a41f509f8945f23c96c7acd4adafd679",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,8 @@ var targets: [Target] = [
         ],
         exclude: ["README.md", "GitConfiguration.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -96,7 +97,8 @@ var targets: [Target] = [
             "Common",
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -109,7 +111,8 @@ var targets: [Target] = [
             "Common",
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -122,7 +125,8 @@ var targets: [Target] = [
             "Common",
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -135,7 +139,8 @@ var targets: [Target] = [
             "Common",
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -154,7 +159,8 @@ var targets: [Target] = [
         ],
         exclude: ["README.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -173,7 +179,8 @@ var targets: [Target] = [
         ],
         exclude: ["README.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -192,7 +199,8 @@ var targets: [Target] = [
         ],
         exclude: ["README.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -211,12 +219,17 @@ var targets: [Target] = [
         ],
         exclude: ["README.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .executableTarget(
         name: "Scout",
-        dependencies: scoutDependencies
+        dependencies: scoutDependencies,
+        swiftSettings: [
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
+        ]
     ),
     .testTarget(
         name: "CommonTests",
@@ -224,7 +237,8 @@ var targets: [Target] = [
             "Common"
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -240,7 +254,8 @@ var targets: [Target] = [
             .copy("Samples")
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -255,7 +270,8 @@ var targets: [Target] = [
             ),
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -267,7 +283,8 @@ var targets: [Target] = [
             .copy("Samples")
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -282,7 +299,8 @@ var targets: [Target] = [
             ),
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -294,7 +312,8 @@ var targets: [Target] = [
             .copy("Samples")
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -309,7 +328,8 @@ var targets: [Target] = [
             ),
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -321,7 +341,8 @@ var targets: [Target] = [
             .copy("Samples")
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -336,7 +357,8 @@ var targets: [Target] = [
             ),
         ],
         swiftSettings: [
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
 ]
@@ -358,7 +380,8 @@ var targets: [Target] = [
                 "Common",
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .target(
@@ -377,7 +400,8 @@ var targets: [Target] = [
             ],
             exclude: ["README.md"],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .testTarget(
@@ -389,7 +413,8 @@ var targets: [Target] = [
                 .copy("Samples")
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .testTarget(
@@ -404,7 +429,8 @@ var targets: [Target] = [
                 ),
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
     ])

--- a/Package.swift
+++ b/Package.swift
@@ -453,7 +453,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/swiftlang/swift-subprocess",
-            from: "0.2.1"
+            from: "0.5.0"
         ),
         .package(
             url: "https://github.com/apple/swift-log.git",

--- a/Sources/BuildSettings/ProjectDiscovery.swift
+++ b/Sources/BuildSettings/ProjectDiscovery.swift
@@ -22,7 +22,7 @@ struct ProjectDiscovery: Sendable {
         let excludePatterns = try exclude.map { try Glob.Pattern($0) }
         let repoPathString = repoPath.path(percentEncoded: false)
 
-        let results = try await Glob.search(
+        let results = Glob.search(
             directory: repoPath,
             include: includePatterns,
             exclude: excludePatterns

--- a/Sources/Common/GitHubActionsLogHandler.swift
+++ b/Sources/Common/GitHubActionsLogHandler.swift
@@ -27,27 +27,19 @@ package struct GitHubActionsLogHandler: LogHandler {
         set {}
     }
 
-    package func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        guard level >= logLevel else { return }
+    package func log(event: LogEvent) {
+        guard event.level >= logLevel else { return }
 
-        let command = workflowCommand(for: level)
+        let command = workflowCommand(for: event.level)
         let parameters = formatParameters(
-            file: file,
-            line: line,
-            function: function,
-            metadata: metadata
+            file: event.file,
+            line: event.line,
+            function: event.function,
+            metadata: event.metadata
         )
 
         // Enrich message step by step
-        var enrichedMessage = enrichWithMetadata(message, metadata: metadata)
+        var enrichedMessage = enrichWithMetadata(event.message, metadata: event.metadata)
         enrichedMessage = enrichWithGitHubActionsAnnotation(
             enrichedMessage,
             command: command,

--- a/Sources/Common/Shell.swift
+++ b/Sources/Common/Shell.swift
@@ -138,7 +138,7 @@ package class Shell {
         }
         logger.debug("Executing command", metadata: metadata)
 
-        let result: CollectedResult<StringOutput<Unicode.UTF8>, StringOutput<Unicode.UTF8>>
+        let result: ExecutionResult<Void, StringOutput<Unicode.UTF8>, StringOutput<Unicode.UTF8>>
         do {
             var configuration = Subprocess.Configuration(
                 executable: .name(executable),


### PR DESCRIPTION
## Summary

Treats all warnings as errors so the build fails on any warning, and fixes the warnings this surfaced.

## Key Changes

- Added `.treatAllWarnings(as: .error)` to every target in `Package.swift`, matching the convention used across dodobrands Swift packages.
- Migrated `GitHubActionsLogHandler` to the `LogHandler.log(event:)` requirement introduced in swift-log 1.14, replacing the now-deprecated flat-parameter `log(level:message:...)` method.
- Dropped a redundant `try await` on `Glob.search`, which is now synchronous and non-throwing.
- Updated swift-subprocess 0.3.0 → 0.5.0. Its old C shim header tripped `-Wnullability-completeness` on the CI Xcode toolchain, which warnings-as-errors escalated to an error; 0.5.0 fully annotates the header. Migrated the renamed result type `CollectedResult` → `ExecutionResult<Void, ...>`.

## Checklist

- [x] Update `Sources/*/README.md` if public API changed
- [x] No warnings from our code during build
