### PR TITLE
fix(types): log per-module symbolgraph failures at debug, not info

### DIFF
--- a/Sources/Common/Shell.swift
+++ b/Sources/Common/Shell.swift
@@ -186,7 +186,10 @@ package class Shell {
                 error: errorOutput
             )
             let errorMessage = error.errorDescription ?? "Command failed"
-            logger.error(
+            // Debug, not error: the throw below is the report. Callers that expect
+            // failures (e.g. per-module symbolgraph extraction) would otherwise
+            // flood the log with each command's full stderr.
+            logger.debug(
                 "Command failed: \(errorMessage)",
                 metadata: [
                     "executable": "\(executable)",

--- a/Sources/Types/SymbolGraphHierarchyProvider.swift
+++ b/Sources/Types/SymbolGraphHierarchyProvider.swift
@@ -68,7 +68,10 @@ actor SymbolGraphHierarchyProvider: ExternalHierarchyProvider {
                 try SymbolGraphParser.objects(fromSymbolGraphJSON: Data(contentsOf: file))
             }
         } catch {
-            Self.logger.info(
+            // Debug: a module without build products (unbuilt project) fails to
+            // extract and is expected. At info this dumps the frontend's full
+            // "Current visible modules" list per module — hundreds of lines each.
+            Self.logger.debug(
                 "Skipping module '\(module)': \(error.localizedDescription)"
             )
             return []


### PR DESCRIPTION
## Проблема

`scout types` (наследование) на каждый модуль зовёт `xcrun swift-symbolgraph-extract`. На несобранном проекте (например, в джобе сбора метрик) каждый вызов падает `Couldn't load module 'X'`, а swift-фронтенд печатает диагностику `Current visible modules:` + весь список видимых модулей — сотни строк.

Этот stderr захватывается `Shell.execute` и логируется **дважды на модуль**: на `error` в самом `Shell` и на `info` в `SymbolGraphHierarchyProvider` (строка `Skipping module 'X': …`). На ~200 модулей × число анализируемых коммитов это превращается в весь лог CI (в реальном прогоне — 240k строк / 10 МБ).

## Фикс

Оба лога → `debug`. Фейлы ожидаемые и не фатальные: наследование резолвится из парсинга исходников, а `Shell` и так бросает ошибку (лог — дублирование). CI гоняет scout без `--verbose` (уровень `info`), так что дампы отсекаются; с `--verbose` полный вывод остаётся для отладки.

Значения метрик не меняются — только объём лога.